### PR TITLE
Fix adding ticket number when message is empty

### DIFF
--- a/pre_ticket/tickets.py
+++ b/pre_ticket/tickets.py
@@ -36,7 +36,10 @@ def add_ticket_number(filename, regex, format_template):
         with io.open(filename, "r+") as fd:
             contents = fd.read()
 
-            if is_ticket_in_message(contents, ticket_number):
+            if (
+                is_ticket_in_message(contents, ticket_number)
+                or not contents[:contents.find("\n")]
+            ):
                 return
 
             ticket_msg = format_template.format(message=contents, ticket=ticket_number)


### PR DESCRIPTION
Sometimes we want to abort creating a commit. Without `pre_ticket` when we close an editor with an empty message it will not be created. But currently `pre_ticket` always adds ticket number to commit message hence it is not possible to abort creating commit after `git commit` command.

The following solution checks if the first line of a commit is empty which should be good enough.