### PR TITLE
Provide removing of comment section

### DIFF
--- a/pre_ticket/tickets.py
+++ b/pre_ticket/tickets.py
@@ -5,9 +5,7 @@ import six
 
 from .commands import call_command
 
-GIT_COMMENT_SECTION_LINE = (
-    "# ------------------------ >8 ------------------------\n"
-)
+GIT_COMMENT_SECTION_LINE = r". -{24} >8 -{24}\n"
 
 
 def get_current_branch():
@@ -39,8 +37,9 @@ def get_message_without_comment_section(message):
     strip it to avoid appending of ticket number bellow this line.
 
     """
-    if GIT_COMMENT_SECTION_LINE in message:
-        return message[:message.find(GIT_COMMENT_SECTION_LINE)]
+    match = re.search(GIT_COMMENT_SECTION_LINE, message)
+    if match is not None:
+        return message[:match.start()]
     return message
 
 

--- a/pre_ticket/tickets.py
+++ b/pre_ticket/tickets.py
@@ -5,6 +5,10 @@ import six
 
 from .commands import call_command
 
+GIT_COMMENT_SECTION_LINE = (
+    "# ------------------------ >8 ------------------------\n"
+)
+
 
 def get_current_branch():
     return call_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
@@ -28,13 +32,25 @@ def is_ticket_in_message(contents, ticket):
             return True
 
 
+def get_message_without_comment_section(message):
+    """Return message without comment section which is located bellow the line.
+
+    All bellow this line will be ignored including ticket number. So need to
+    strip it to avoid appending of ticket number bellow this line.
+
+    """
+    if GIT_COMMENT_SECTION_LINE in message:
+        return message[:message.find(GIT_COMMENT_SECTION_LINE)]
+    return message
+
+
 def add_ticket_number(filename, regex, format_template):
     branch = get_current_branch()
     ticket_number = retrieve_ticket(branch, regex)
 
     if ticket_number:
         with io.open(filename, "r+") as fd:
-            contents = fd.read()
+            contents = get_message_without_comment_section(fd.read())
 
             if (
                 is_ticket_in_message(contents, ticket_number)


### PR DESCRIPTION
There is line in commit message which will be considered as comment section line and everything bellow this line will be ignored including ticket number, so need to strip it before appending ticket number to avoid appending ticket bellow the line.