### PR TITLE
Fix leading ticket number

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: tests
+
+on: push
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: |
+          pip install six pytest
+      - run: pytest

--- a/pre_ticket/tickets.py
+++ b/pre_ticket/tickets.py
@@ -18,6 +18,26 @@ def retrieve_ticket(branch, regex):
 
 
 def is_ticket_in_message(contents, ticket):
+    """
+    Checks if a specified ticket is present in the given message contents.
+
+    This function scans through each line of the provided message contents,
+    ignoring empty lines and comments (except for the first line), to determine
+    if the specified ticket is mentioned. It performs a case-insensitive search
+    for the ticket within the non-empty, non-comment lines.
+
+    The first line is an exception because some conventions assume that the task
+    number preceded by a hashtag will appear at the beginning of the commit
+    message: "#123 Commit Message".
+
+    Examples:
+    >>> is_ticket_in_message("This is a message with ticket #123", "#123")
+    True
+    >>> is_ticket_in_message("This is a message without a ticket", "#123")
+    False
+    >>> is_ticket_in_message("#123 This is a message with a ticket", "#123")
+    True
+    """
     for i, line in enumerate(contents.splitlines()):
         stripped = line.strip().lower()
 

--- a/pre_ticket/tickets.py
+++ b/pre_ticket/tickets.py
@@ -18,15 +18,16 @@ def retrieve_ticket(branch, regex):
 
 
 def is_ticket_in_message(contents, ticket):
-    for line in contents.splitlines():
+    for i, line in enumerate(contents.splitlines()):
         stripped = line.strip().lower()
 
-        if stripped == "" or stripped.startswith("#"):
+        if stripped == "" or (stripped.startswith("#") and i != 0):
             continue
 
         if ticket.lower() in stripped:
             return True
 
+    return False
 
 def add_ticket_number(filename, regex, format_template):
     branch = get_current_branch()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     ],
     description="pre-commit hook for adding issue ticket number to your git commit messages",
     install_requires=requirements,
+    tests_require=["pytest"],
     name="pre_ticket",
     version="1.0.0",
     license="MIT license",

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -1,0 +1,38 @@
+from pre_ticket.tickets import is_ticket_in_message
+import pytest
+
+
+with_ticket_1 = """#1234 Updated some code
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored.
+"""
+
+with_ticket_2 = """Updated some code
+
+Ref: #1234
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored.
+"""
+
+without_ticket_1 = ""
+
+without_ticket_2 = """Updated some code
+
+# 1234
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored.
+"""
+
+@pytest.mark.parametrize(
+    ("content", "expected_result"),
+    [
+        (without_ticket_1, False),
+        (without_ticket_2, False),
+        (with_ticket_1, True),
+        (with_ticket_2, True),
+    ]
+)
+def test_is_ticket_in_message(content, expected_result):
+    assert is_ticket_in_message(content, "1234") is expected_result


### PR DESCRIPTION
**Current behavior:**

When the `--format` argument starts with `#{ticket}`, during `git commit --amend --no-edit` an additional task number was added at the beginning.

**Expected behavior:**

When the commit message starts with `#{ticket}` (only on the first line), do not add it again.

**Fix applied:**

Skip the line starting with `#` only if it is not the first line.